### PR TITLE
Rename update_specs and update the README a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
-Specs and Tools for the Hardware Design course
+# Specs and Tools for the Hardware Design course
 
-
-**./updateSpecs**
+## updateSpecs
 Updates your specs to the latest version in the repository.
 
-This is done with:
-	
+```
+./updateSpecs
+```
+
+Internally, this uses:
+
 	rm -r specs/_cache
 	git pull origin master
 
-The rm removes the cached .json files because they can get messed up when a new assignment is added.
+We remove the cached `.json` files because they can get messed up when a new assignment is added.
 
+## CheckDates
+```
+./CheckDates [-a (hw# | lab# | ws#)...] [-s students...]
+```
 
-**./CheckDates [-a (hw# | lab# | ws#)...] [-s students...]**
-*To create CheckDates, run make from the source subdirectory.* 
-Finds the date of the first commit for each student for each assignment. Specify individual students with -s, otherwise omit for all students. Specify assignments after -a. These are printed out to the terminal. If a specified spec is not found in the cache, the program will automatically run cs251tk to cache them.
+> To create CheckDates, run `make` from the source subdirectory.
+
+Finds the date of the first commit for each student for each assignment. Specify individual students with `-s`, otherwise omit for all students. Specify assignments after `-a`. These are printed out to the terminal. If a specified spec is not found in the cache, the program will automatically run `cs251tk` to cache them.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Specs and Tools for the Hardware Design course
 
-## updateSpecs
+## update_specs.sh
 Updates your specs to the latest version in the repository.
 
 ```
-./updateSpecs
+./update_specs.sh
 ```
 
 Internally, this uses:

--- a/update_specs.sh
+++ b/update_specs.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 rm -r specs/_cache
 git pull origin master


### PR DESCRIPTION
Hey @maxnz!

I poked at the README's formatting a little bit, and renamed `updatespecs` to `update_specs.sh` – both to clarify that it's a shell script (personal preference) and to prevent mis-capitalization issues on case-insensitive filesystems (between `updateSpecs` and `updatespecs`).